### PR TITLE
Allow caller to set flags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@ export default function closure(flags = {}) {
     return {
         name: 'closure-compiler-js',
         transformBundle(code) {
-            flags.createSourceMap = true;
-            flags.processCommonJsModules = true;
+            flags = Object.assign({
+              createSourceMap: true,
+              processCommonJsModules: true
+            }, flags);
             flags.jsCode = [{
                 src: code
             }];


### PR DESCRIPTION
I'd like to be able to configure the compiler with `processCommonJsModules: false`.

Let me know if you think this should be handled a different way.
