### PR TITLE
Add additional badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# rollup-plugin-closure-compiler-js [![Travis Build Status][travis-img]][travis]
+# rollup-plugin-closure-compiler-js
 
-[travis-img]: https://travis-ci.org/camelaissani/rollup-plugin-closure-compiler-js.svg
-[travis]: https://travis-ci.org/camelaissani/rollup-plugin-closure-compiler-js
+[![Build Status](https://travis-ci.org/camelaissani/rollup-plugin-closure-compiler-js.svg)](https://travis-ci.org/camelaissani/rollup-plugin-closure-compiler-js)
+[![latest version](https://img.shields.io/npm/v/rollup-plugin-closure-compiler-js.svg)](https://www.npmjs.com/package/rollup-plugin-closure-compiler-js)
+[![license](https://img.shields.io/npm/l/rollup-plugin-closure-compiler-js.svg)](https://github.com/camelaissani/rollup-plugin-closure-compiler-js/blob/master/LICENSE)
+[![dependencies Status](https://david-dm.org/camelaissani/rollup-plugin-closure-compiler-js/status.svg)](https://david-dm.org/camelaissani/rollup-plugin-closure-compiler-js)
+[![devDependencies Status](https://david-dm.org/camelaissani/rollup-plugin-closure-compiler-js/dev-status.svg)](https://david-dm.org/camelaissani/rollup-plugin-closure-compiler-js?type=dev)
 
 [Rollup](https://github.com/rollup/rollup) plugin to invoke google-closure-compiler-js.
 


### PR DESCRIPTION
This adds a couple of info badges to the `README.md`:
- npm version
- license
- [david-dm.org](https://david-dm.org) dependencies + devDependencies
- reformatted onto single line

As per comment in #8 