### PR TITLE
Fix closure-compiler logger (upgraded to latest version)

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -49,39 +49,17 @@ export default function(options, output, logger) {
     if (!file) { return null; }
 
     // Filenames are the same across source and externs, so prefer source files.
-    const inputFiles = [...options.jsCode];
-    if (options.externs) {
-      inputFiles.push(...options.externs);
-    }
+    for (const files of [options.jsCode, options.externs]) {
+      if (!files) { continue; }
 
-    // if path not set and only one input file then return it
-    if (inputFiles.length === 1) {
-      return inputFiles[0];
-    }
-
-    for (const file of inputFiles) {
-      if (cand.path == file) {
-        return cand;
+      for (const cand of files) {
+        if (cand.path == file) {
+          return cand;
+        }
       }
     }
 
     return null;
-  }
-
-  function writeCodeContext(lineIndex, lines, before=true) {
-    const maxContextLines = 4;
-    let index = before ? lineIndex - maxContextLines : lineIndex + 1;
-    if (index < 0) {
-      return;
-    }
-    let printedLine = 0;
-    for (index; index < lines.length; ++index) {
-      logger(lines[index] || '');
-      printedLine++;
-      if (printedLine === maxContextLines) {
-        return;
-      }
-    }
   }
 
   function writemsg(color, msg) {
@@ -95,16 +73,9 @@ export default function(options, output, logger) {
     const file = fileFor(msg.file);
     if (file) {
       const lines = file.src.split('\n');  // TODO(samthor): cache this for logger?
-      const lineIndex = msg.lineNo - 1;
-
-      // before guilty line context
-      writeCodeContext(lineIndex, lines);
-      // guilty line
-      const line = lines[lineIndex] || '';
+      const line = lines[msg.lineNo - 1] || '';
       logger(color + line + COLOR_END);
       logger(COLOR_GREEN + caretPrefix(line, msg.charNo) + '^' + COLOR_END);
-      // after guilty line context
-      writeCodeContext(lineIndex, lines, false);
     }
     logger('');
   }


### PR DESCRIPTION
Fixes error output of the rollup plugin
```
🚨   (closure-compiler-js plugin) Error transforming bundle with 'closure-compiler-js' plugin: cand is not defined
```